### PR TITLE
Remove licene from individual .py files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ msibi/tutorials/lj/rdfs/pair*
 msibi/tutorials/lj/state*/*.txt
 msibi/tutorials/lj/potentials/
 msibi/tutorials/lj/state*/run.py
-
 # Default files
+*.ipynb
 *.pyc
 *.dcd
 .DS_Store

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -1,34 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-# Contributors: Davy Yue
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
-
 from __future__ import division
 
 import os

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -1,32 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 from __future__ import division
 
 import os

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -1,33 +1,3 @@
-############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-# Contributors: Davy Yue
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 import os
 
 import gsd

--- a/msibi/workers.py
+++ b/msibi/workers.py
@@ -1,33 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-# Contributors: Davy Yue
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 from __future__ import division, print_function
 
 import itertools


### PR DESCRIPTION
I think we should remove the license from the individual .py files. It's a little cumbersome to scroll past them every time you open a file. We can either add them back in after the amount of dev work slows down, or maybe we decide having the license in the main repo is enough.

Also, I added `.ipynb` to the gitignore file