### PR TITLE
Remove license from individual files (again)

### DIFF
--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -1,32 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 from __future__ import division
 
 import numpy as np

--- a/msibi/utils/error_calculation.py
+++ b/msibi/utils/error_calculation.py
@@ -1,32 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 from __future__ import division
 
 import numpy as np

--- a/msibi/utils/exceptions.py
+++ b/msibi/utils/exceptions.py
@@ -1,34 +1,4 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 SUPPORTED_ENGINES = ["hoomd"]
-
 
 class UnsupportedEngine(Exception):
     def __init__(self, engine):

--- a/msibi/utils/find_exclusions.py
+++ b/msibi/utils/find_exclusions.py
@@ -1,32 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 import networkx as nx
 import numpy as np
 from networkx import NetworkXNoPath

--- a/msibi/utils/general.py
+++ b/msibi/utils/general.py
@@ -1,32 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 import glob
 import os
 import shutil

--- a/msibi/utils/smoothing.py
+++ b/msibi/utils/smoothing.py
@@ -1,32 +1,3 @@
-##############################################################################
-# MSIBI: A package for optimizing coarse-grained force fields using multistate
-#   iterative Boltzmann inversion.
-# Copyright (c) 2017 Vanderbilt University and the Authors
-#
-# Authors: Christoph Klein, Timothy C. Moore
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files, to deal
-# in MSIBI without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# # copies of MSIBI, and to permit persons to whom MSIBI is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of MSIBI.
-#
-# MSIBI IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH MSIBI OR THE USE OR OTHER DEALINGS ALONG WITH
-# MSIBI.
-#
-# You should have received a copy of the MIT license.
-# If not, see <https://opensource.org/licenses/MIT/>.
-##############################################################################
-
 from __future__ import division
 
 from math import factorial


### PR DESCRIPTION
I missed all of the files in the `utils` directory in #5, this should take care of those