### PR TITLE
target RDF an attribute of State class, added target_rdf_calc method

### DIFF
--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -157,7 +157,8 @@ class Pair(object):
         np.savetxt(os.path.join(
             state.dir,
             f"pair_{self.name}-state_{state.name}-steo{iteration}.txt"
-            )
+            ),
+            rdf)
 
     def update_potential(self, pot_r, r_switch=None, verbose=False):
         """Update the potential using all states. """

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -43,7 +43,7 @@ class Pair(object):
         self.head_correction_form = head_correction_form
 
     def add_state(
-        self, state, alpha, pair_indices=None, alpha_form="linear"
+        self, state, pair_indices=None, alpha_form="linear"
     ):
         """Add a state to be used in optimizing this pair.
 
@@ -51,8 +51,6 @@ class Pair(object):
         ----------
         state : State
             A state object.
-        alpha : float
-            The alpha value used to scale the weight of this state.
         pair_indices : array-like (n_pairs, 2) dtype=int
             Each row gives the indices of two atoms representing a pair
             (default None)
@@ -64,7 +62,7 @@ class Pair(object):
         self.states[state] = {
             "target_rdf": target_rdf,
             "current_rdf": None,
-            "alpha": alpha,
+            "alpha": state.alpha,
             "alpha_form": alpha_form,
             "pair_indices": pair_indices,
             "f_fit": [],
@@ -154,14 +152,12 @@ class Pair(object):
         dr : float
             The RDF bin size
         """
-        if not os.path.isdir("./rdfs"):
-            os.makedirs("./rdfs")
-        filename = "./rdfs/pair_{0}-state_{1}-step{2}.txt".format(
-            self.name, state.name, iteration
-        )
         rdf = self.states[state]["current_rdf"]
         rdf[:, 0] -= dr / 2
-        np.savetxt(filename, rdf)
+        np.savetxt(os.path.join(
+            state.dir,
+            f"pair_{self.name}-state_{state.name}-steo{iteration}.txt"
+            )
 
     def update_potential(self, pot_r, r_switch=None, verbose=False):
         """Update the potential using all states. """

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -43,7 +43,7 @@ class Pair(object):
         self.head_correction_form = head_correction_form
 
     def add_state(
-        self, state, target_rdf, alpha, pair_indices=None, alpha_form="linear"
+        self, state, alpha, pair_indices=None, alpha_form="linear"
     ):
         """Add a state to be used in optimizing this pair.
 
@@ -51,8 +51,6 @@ class Pair(object):
         ----------
         state : State
             A state object.
-        target_rdf : np.ndarray, shape=(n_bins, 2), dtype=float
-            Coarse-grained target RDF.
         alpha : float
             The alpha value used to scale the weight of this state.
         pair_indices : array-like (n_pairs, 2) dtype=int
@@ -62,6 +60,7 @@ class Pair(object):
             For alpha as a function of r, gives form of alpha function
             (default 'linear')
         """
+        target_rdf = np.loadtxt(state.target_rdf)
         self.states[state] = {
             "target_rdf": target_rdf,
             "current_rdf": None,
@@ -173,8 +172,8 @@ class Pair(object):
             form = self.states[state]["alpha_form"]
             alpha = alpha_array(alpha0, pot_r, form=form)
 
-            current_rdf = self.states[state]["current_rdf"][:, 1]
-            target_rdf = self.states[state]["target_rdf"][:, 1]
+            current_rdf = self.states[state]["current_rdf"][:, 1] #nparray
+            target_rdf = self.states[state]["target_rdf"][:, 1] #nparray
 
             # For cases where rdf_cutoff != pot_cutoff, only update the
             # potential using RDF values < pot_cutoff.

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -74,20 +74,20 @@ class State(object):
         self.traj_file = traj_file
         self.traj = None
         self.backup_trajectory = backup_trajectory
+        self.target_rdf = os.path.join(self.dir, "target_rdf.txt")
         
         if target_rdf is not None:
             # Target RDF passed into State class in the form of a txt file
             # Copy to self.dir, rename to target_rdf.txt
-
-            if os.path.isfile(target_rdf):
+            if isinstance(target_rdf, str):
                 shutil.copyfile(target_rdf,
                         os.path.join(self.dir, "target_rdf.txt")
                         )
         
             # Target RDF passed in State class in the form of an array of data
             # Save in self.dir, name target_rdf.txt
-            elif isinstancae(target_rdf, np.array):
-                np.savetxt(os.path.join(self.dir, "target_rdf.txt"))
+            elif isinstance(target_rdf, np.ndarray):
+                np.savetxt(os.path.join(self.dir, "target_rdf.txt"), target_rdf)
 
     
     def target_rdf_calc(


### PR DESCRIPTION
This PR makes a few changes to how a State object is initialized.

1. The creation of the state specific directories are handled automatically
2. A state's target rdf is now a property of that State object. 
3. A method is available within the State class that calculates the target rdf

The goal is to streamline the overall process. Rather than managing and organizing the target rdfs separately from their corresponding states, they become wrapped up into the state class .

There are basically 2 ways of handling target RDFs for a state:
1. You already have the data available, either as a numpy array or a text file. In this case, you can pass this information in when creating a State object.
2. You don't have target RDFs yet. You can still initiate a State object from it's trajectory, and call the `target_rdf_calc` method which will calculate and save the target RDF.

Here is a [Gist exmaple](https://gist.github.com/chrisjonesBSU/fce12f8f09423e8fdf0a4a9c24c34f04) that goes through the different ways of handling a target rdf when creating a State

I haven't gone through the rest of the files to account for the changes to the `State` class.

To Do:

- [ ] Unit tests
- [ ] Make needed changes to the rest of the code base to use `State.target_rdf`