### PR TITLE
Add return statement to exponential head correction

### DIFF
--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 
 from msibi.utils.general import find_nearest
@@ -66,7 +68,7 @@ def head_correction(r, V, previous_V, form="linear"):
     elif form == "exponential":
         correction_function = exponential_head_correction
     else:
-        raise ValueError('Unsupported head correction form: "{0}"'.format(form))
+        raise ValueError(f'Unsupported head correction form: "{form}"')
 
     for i, pot_value in enumerate(V[::-1]):
         # Apply correction function because either of the following is true:
@@ -89,9 +91,11 @@ def head_correction(r, V, previous_V, form="linear"):
                 V[i] = previous_V[i]
             return V
     else:
-        # TODO: Raise error?
-        #       This means that all potential values are well behaved.
-        pass
+        warnings.warn(
+            "No inf/nan values in your potential--this is unusual!"
+            "No head correction applied"
+        )
+        return V
 
 
 def linear_head_correction(r, V, cutoff):

--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -121,7 +121,7 @@ def exponential_head_correction(r, V, cutoff):
     dr = r[cutoff + 2] - r[cutoff + 1]
     B = np.log(V[cutoff + 1] / V[cutoff + 2]) / dr
     A = V[cutoff + 1] * np.exp(B * r[cutoff + 1])
-    V[: cutoff + 1] = A * np.exp(-B * r[: cutoff + 1])
+    return V[: cutoff + 1] = A * np.exp(-B * r[: cutoff + 1])
 
 
 def alpha_array(alpha0, pot_r, form="linear"):

--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -121,7 +121,8 @@ def exponential_head_correction(r, V, cutoff):
     dr = r[cutoff + 2] - r[cutoff + 1]
     B = np.log(V[cutoff + 1] / V[cutoff + 2]) / dr
     A = V[cutoff + 1] * np.exp(B * r[cutoff + 1])
-    return V[: cutoff + 1] = A * np.exp(-B * r[: cutoff + 1])
+    V[: cutoff + 1] = A * np.exp(-B * r[: cutoff + 1])
+    return V
 
 
 def alpha_array(alpha0, pot_r, form="linear"):

--- a/msibi/tests/test_potentials.py
+++ b/msibi/tests/test_potentials.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from msibi.potentials import alpha_array, mie, tail_correction
+from msibi.potentials import alpha_array, mie, tail_correction, head_correction
 
 
 def test_tail_correction():
@@ -24,3 +24,21 @@ def test_calc_alpha_array():
     form = "margaret-thatcher"
     with pytest.raises(ValueError):
         alpha = alpha_array(alpha0, r, form)
+
+
+def test_head_correction():
+    dr = 0.05
+    cutoff = 8
+    r = np.arange(0, 2.5, dr)
+    V_prev = mie(r, 1, 1)
+    V = mie(r, 2, 1)
+    V[:cutoff] = np.inf
+
+    linear_V = head_correction(r, V, V_prev, "linear")
+    assert not np.isnan(linear_V).any() and not np.isinf(linear_V).any()
+    assert all(linear_V[cutoff:] == V[cutoff:])
+
+    exp_V = head_correction(r, V, V_prev, "exponential")
+    assert not np.isnan(exp_V).any() and not np.isinf(exp_V).any()
+    assert all(exp_V[cutoff:] == V[cutoff:])
+    assert exp_V > linear_V

--- a/msibi/tests/test_potentials.py
+++ b/msibi/tests/test_potentials.py
@@ -34,11 +34,11 @@ def test_head_correction():
     V = mie(r, 2, 1)
     V[:cutoff] = np.inf
 
-    linear_V = head_correction(r, V, V_prev, "linear")
+    linear_V = head_correction(r, np.copy(V), V_prev, "linear")
     assert not np.isnan(linear_V).any() and not np.isinf(linear_V).any()
     assert all(linear_V[cutoff:] == V[cutoff:])
 
-    exp_V = head_correction(r, V, V_prev, "exponential")
+    exp_V = head_correction(r, np.copy(V), V_prev, "exponential")
     assert not np.isnan(exp_V).any() and not np.isinf(exp_V).any()
     assert all(exp_V[cutoff:] == V[cutoff:])
-    assert exp_V > linear_V
+    assert exp_V[0] > linear_V[0]


### PR DESCRIPTION
Without a return, the exponential correction set the potential to `None`. 🙃 This PR fixes that.
- [x] We should also add a unit tests to catch this failure 