### PR TITLE
Create initial potential guess from Boltzmann Inverse of Target RDF

### DIFF
--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -185,7 +185,7 @@ class MSIBI(object):
                          "but setting `derive_init_potential` to True will "
                          "override and create a new initial pair potential."
                     )
-                initial_pot = np.zeros(len(self.opt_r))
+                initial_pot = np.zeros(len(self.pot_r))
                 for state in self.states:
                     initial_pot += (-state.kT*np.log(
                         pair._states[state]["target_rdf"][:,1]

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -180,7 +180,7 @@ class MSIBI(object):
                         pair._states[state]["target_rdf"][:,1]
                     )*state.alpha)
 
-                pair.potential = savitzky_golay(initial_pot, 15, 1, 0, 1)
+                pair.potential = initial_pot
 
         if self.bonds:
             for bond in self.bonds:

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -1,4 +1,5 @@
 import os
+from warnings import warn
 
 import numpy as np
 
@@ -179,14 +180,24 @@ class MSIBI(object):
 
             ## Update initial potential here ##
             if derive_init_potential is True:
+                if pair.potential != None:
+                    warn("You passed in an initial potential for this pair, "
+                         "but setting `derive_init_potential` to True will "
+                         "override and create a new initial pair potential."
+                    )
                 initial_pot = np.zeros(len(self.opt_r))
                 for state in self.states:
                     initial_pot += (-state.kT*np.log(
                         pair._states[state]["target_rdf"][:,1]
-                    )*state.alpha
+                    )*state.alpha)
+
                 pair.potential = initial_pot
-            else:
-                assert pair.potential != None
+            elif derive_init_potential is False and pair.potential is None:
+                raise ValueError("The initial pair potentials were not set "
+                        "when the Pair() objects were created. You must either "
+                        "manually pass in initial potentials for each pair, or "
+                        "set `derive_init_potential` to True."
+                    )
 
         if self.bonds:
             for bond in self.bonds:

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -131,7 +131,6 @@ class MSIBI(object):
         n_iterations=10,
         start_iteration=0,
         n_steps=1e6,
-        derive_init_potential=False,
         engine="hoomd",
         _dir=None
     ):
@@ -155,11 +154,6 @@ class MSIBI(object):
         n_steps : int, default=1e6
             How many steps to run the query simulations
             The frequency to write trajectory information to query.gsd
-        derive_init_potential : boolean, default False
-            Set to True if you want to derive the initial pair potential
-            from the weighted Boltzmann inverse of the state-pair target RDFs.
-            If False, then the initial potential must be defined when creating
-            a new Pair object.
         engine : str, default "hoomd"
             Engine that runs the simulations.
 
@@ -178,13 +172,7 @@ class MSIBI(object):
             for state in self.states:
                 pair._add_state(state, smooth=self.smooth_rdfs)
 
-            ## Update initial potential here ##
-            if derive_init_potential is True:
-                if pair.potential != None:
-                    warn("You passed in an initial potential for this pair, "
-                         "but setting `derive_init_potential` to True will "
-                         "override and create a new initial pair potential."
-                    )
+            if pair.potential is None:
                 initial_pot = np.zeros(len(self.pot_r))
                 for state in self.states:
                     initial_pot += (-state.kT*np.log(
@@ -192,12 +180,6 @@ class MSIBI(object):
                     )*state.alpha)
 
                 pair.potential = initial_pot
-            elif derive_init_potential is False and pair.potential is None:
-                raise ValueError("The initial pair potentials were not set "
-                        "when the Pair() objects were created. You must either "
-                        "manually pass in initial potentials for each pair, or "
-                        "set `derive_init_potential` to True."
-                    )
 
         if self.bonds:
             for bond in self.bonds:

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from msibi.potentials import tail_correction
 from msibi.utils.exceptions import UnsupportedEngine
+from msibi.utils.smoothing import savitzky_golay
 from msibi.workers import run_query_simulations
 
 
@@ -179,7 +180,7 @@ class MSIBI(object):
                         pair._states[state]["target_rdf"][:,1]
                     )*state.alpha)
 
-                pair.potential = initial_pot
+                pair.potential = savitzky_golay(initial_pot, 15, 1, 0, 1)
 
         if self.bonds:
             for bond in self.bonds:

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -25,11 +25,17 @@ class Pair(object):
         The name of one particle type on the particle pair.
         Must match the names found in the State's .gsd trajectory file.
         See  gsd.hoomd.ParticleData.types
-    potential :
-
+    potential : 1D numpy array or None   
+        Values of the potential at every pot_r.
+        Leave as None to derive an initial potential from the weighted average
+        of the Boltzmann inverse from each State's target RDF.
 
     Attributes
     ----------
+    type1 : str
+        Name/type of the first particle in this pair.
+    type2 : 
+        Name/type of the second particle in this pair.
     name : str
         Pair name.
     potential : 1D numpy array   

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -1,4 +1,5 @@
 import os
+form warnings import warn
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -35,7 +36,7 @@ class Pair(object):
         Values of the potential at every pot_r.
     """
 
-    def __init__(self, type1, type2, potential, head_correction_form="linear"):
+    def __init__(self, type1, type2, potential=None, head_correction_form="linear"):
         self.type1 = str(type1)
         self.type2 = str(type2)
         self.name = f"{self.type1}-{self.type2}"
@@ -43,9 +44,15 @@ class Pair(object):
         self._states = dict()
         if isinstance(potential, str):
             self.potential = np.loadtxt(potential)[:, 1]
-            # TODO: this could be dangerous
-        else:
+        elif isinstance(potential, numpy.ndarray):
             self.potential = potential
+        elif potential == None:
+            warn("Initial potential not created for "
+                f"pair {self.type1}-{self.type2}. "
+                "Set `derive_init_potential to True "
+                "when calling the optimize step."
+                )
+            self.potential = None 
         self.previous_potential = None
         self.head_correction_form = head_correction_form
 
@@ -93,7 +100,8 @@ class Pair(object):
         return np.stack((rdf.bin_centers, rdf.rdf*norm)).T
 
     def compute_current_rdf(self, state, smooth, verbose=False, query=True):
-
+        """
+        """
         rdf = self.get_state_rdf(state, query=query)
         self._states[state]["current_rdf"] = rdf
 

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -32,7 +32,7 @@ class Pair(object):
     ----------
     name : str
         Pair name.
-    potential : func
+    potential : 1D numpy array   
         Values of the potential at every pot_r.
     """
 
@@ -42,20 +42,17 @@ class Pair(object):
         self.name = f"{self.type1}-{self.type2}"
         self.potential_file = ""
         self._states = dict()
-        if isinstance(potential, str):
-            self.potential = np.loadtxt(potential)[:, 1]
-        elif isinstance(potential, np.ndarray):
+        if isinstance(potential, np.ndarray):
             self.potential = potential
         elif potential == None:
             warn("Initial potential not created for "
                 f"pair {self.type1}-{self.type2}. "
-                "Set `derive_init_potential to True "
-                "when calling the optimize step."
+                "The initial potential will be created by "
+                "the Boltzmann inverse of the target RDFs."
                 )
             self.potential = None 
         self.previous_potential = None
         self.head_correction_form = head_correction_form
-
 
     def _add_state(self, state, smooth=True):
         """Add a state to be used in optimizing this pair.

--- a/msibi/pair.py
+++ b/msibi/pair.py
@@ -1,5 +1,5 @@
 import os
-form warnings import warn
+from warnings import warn
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -44,7 +44,7 @@ class Pair(object):
         self._states = dict()
         if isinstance(potential, str):
             self.potential = np.loadtxt(potential)[:, 1]
-        elif isinstance(potential, numpy.ndarray):
+        elif isinstance(potential, np.ndarray):
             self.potential = potential
         elif potential == None:
             warn("Initial potential not created for "

--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -17,8 +17,6 @@ def morse(r, D, alpha, r0):
     """Morse pair potential. """
     return D * (np.exp(-2 * alpha * (r - r0)) - 2 * np.exp(-alpha * (r - r0)))
 
-def boltzmann_inverse(rdf_y, kT):
-    return -kT*np.log(rdf_y)
 
 def tail_correction(r, V, r_switch):
     """Apply a tail correction to a potential making it go to zero smoothly.

--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -17,6 +17,8 @@ def morse(r, D, alpha, r0):
     """Morse pair potential. """
     return D * (np.exp(-2 * alpha * (r - r0)) - 2 * np.exp(-alpha * (r - r0)))
 
+def boltzmann_inverse(rdf_y, kT):
+    return -kT*np.log(rdf_y)
 
 def tail_correction(r, V, r_switch):
     """Apply a tail correction to a potential making it go to zero smoothly.

--- a/msibi/tests/test_pair.py
+++ b/msibi/tests/test_pair.py
@@ -19,6 +19,24 @@ class TestPair(BaseTest):
     def test_pair_name(self, pair):
         assert pair.name == "0-1"
 
+    def test_potential_none(self, state0, tmp_path):
+        opt = MSIBI(2.5, n_bins, smooth_rdfs=True)
+        with pytest.warns(UserWarning):
+            pair = Pair("0", "1", potential=None)
+        assert pair.potential == None
+
+        opt.add_pair(pair)
+        opt.add_state(state0)
+        opt.optimize(
+                n_iterations=0,
+                _dir=tmp_path,
+                integrator="hoomd.md.integrate.nvt",
+                integrator_kwargs={"tau": 0.1},
+                dt=0.001,
+                gsd_period=1000
+            )
+        assert isinstance(pair.potential, np.ndarray)
+
     def test_save_table_potential(self, tmp_path):
         pair = Pair("A", "B", potential=mie(r, 1.0, 1.0))
         pair.potential_file = os.path.join(tmp_path, "pot.txt")


### PR DESCRIPTION
This PR adds functionality to create the initial guess pair potentials by taking the Boltzmann inverse of the target RDFs for each pair-state.

It uses a weighted average of each state's target RDF when creating a pair potential. 

To Do:

- [x] Unit Tests
- [ ] Smooth the initial potential