### PR TITLE
Add nlist, exclusions, and smoothing of final potentials

### DIFF
--- a/msibi/bonds.py
+++ b/msibi/bonds.py
@@ -185,8 +185,13 @@ class Bond(object):
                 )
                 negative_idx = np.where(target_distribution[:,1] < 0)[0]
                 target_distribution[:,1][negative_idx] = 0
+
+            fname = f"bond_dist_{self.name}-state_{state.name}-target.txt"
+            fpath = os.path.join(state.dir, fname)
+            np.savetxt(fpath, target_distribution)
         else:
             target_distribution = None
+
         self._states[state] = {
                 "target_distribution": target_distribution,
                 "current_distribution": None,
@@ -194,7 +199,7 @@ class Bond(object):
                 "alpha_form": "linear",
                 "f_fit": [],
                 "path": state.dir
-            }
+        }
 
     def _get_state_distribution(self, state, bins, query=False):
         """Find the bond length distribution of a Bond at a State."""
@@ -231,7 +236,7 @@ class Bond(object):
         f_fit = calc_similarity(
                     bond_distribution[:,1],
                     self._states[state]["target_distribution"][:,1] 
-                )
+        )
         self._states[state]["f_fit"].append(f_fit)
 
     def _save_current_distribution(self, state, iteration):
@@ -436,6 +441,10 @@ class Angle(object):
                 )
                 negative_idx = np.where(target_distribution[:,1] < 0)[0]
                 target_distribution[:,1][negative_idx] = 0
+                
+            fname = f"angle_dist_{self.name}-state_{state.name}-target.txt"
+            fpath = os.path.join(state.dir, fname)
+            np.savetxt(fpath, target_distribution)
         else:
             target_distribution = None
 
@@ -446,7 +455,7 @@ class Angle(object):
                 "alpha_form": "linear",
                 "f_fit": [],
                 "path": state.dir
-            }
+        }
 
     def _get_state_distribution(self, state, bins, query=False):
         """Finds the distribution of angles for a given Angle"""

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -33,6 +33,8 @@ class MSIBI(object):
     max_frames : int, required
         How many snapshots of the trajectories to use in calcualting
         relevant distributions (RDFs, bond distributions)
+    nlist_exclusions : list of str, optional, default ["1-2", "1-3"]
+        Sets the pair exclusions used during the optimization simulations
 
     Attributes
     ----------
@@ -78,11 +80,13 @@ class MSIBI(object):
     ):
         if integrator == "hoomd.md.integrate.nve":
             raise ValueError("The NVE ensemble is not supported with MSIBI")
+
         assert nlist in [
                 "hoomd.md.nlist.cell",
                 "hoomd.md.nlist.tree",
                 "hoomd.md.nlist.stencil"
-        ], ""
+        ], "Enter a valid Hoomd neighbor list type"
+
         self.nlist = nlist 
         self.integrator = integrator
         self.integrator_kwargs = integrator_kwargs

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -132,7 +132,7 @@ class MSIBI(object):
                     r=bond.l_range,
                     dr=bond.dl,
                     iteration=None,
-                    potential_file=file_name
+                    potential_file=os.path.join(self.potentials_dir, file_name)
             )
 
     def optimize_angles(
@@ -171,7 +171,7 @@ class MSIBI(object):
                     r=angle.theta_range,
                     dr=angle.dtheta,
                     iteration=None,
-                    potential_file=file_name
+                    potential_file=os.path.join(self.potentials_dir, file_name)
             )
 
     def optimize_pairs(
@@ -218,6 +218,19 @@ class MSIBI(object):
             print(f"-------- Iteration {n} --------")
             run_query_simulations(self.states)
             self._update_potentials(n)
+
+        for pair in self.pairs:
+            smoothed_pot = savitzky_golay(
+                    pair.potential, window_size=7, order=1
+            )
+            file_name = f"{pair.name}_smoothed.txt"
+            save_table_potential(
+                    potential=smoothed_pot,
+                    r=pair.r_range,
+                    dr=pair.dr,
+                    iteration=None,
+                    potential_file=os.path.join(self.potentials_dir, file_name)
+            )
 
     def _add_states(self):
         """Add State objects to Pairs, Bonds, and Angles.

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 
 from msibi.potentials import pair_tail_correction, save_table_potential
+from msibi.utils.smoothing import savitzky_golay
 from msibi.utils.exceptions import UnsupportedEngine
 from msibi.workers import run_query_simulations
 
@@ -120,6 +121,19 @@ class MSIBI(object):
             print(f"-------- Iteration {n} --------")
             run_query_simulations(self.states)
             self._update_potentials(n)
+        # Save final potential
+        for bond in self.bonds:
+            smoothed_pot = savitzky_golay(
+                    bond.potential, window_size=7, order=1
+            )
+            file_name = f"{bond.name}_smoothed.txt"
+            save_table_potential(
+                    potential=smoothed_pot,
+                    r=bond.l_range,
+                    dr=bond.dl,
+                    iteration=None,
+                    potential_file=file_name
+            )
 
     def optimize_angles(
             self, n_iterations, start_iteration=0, smooth=True, _dir=None
@@ -146,6 +160,19 @@ class MSIBI(object):
             print(f"-------- Iteration {n} --------")
             run_query_simulations(self.states)
             self._update_potentials(n)
+        # Save final potential
+        for angle in self.angles:
+            smoothed_pot = savitzky_golay(
+                    angle.potential, window_size=7, order=1
+            )
+            file_name = f"{angle.name}_smoothed.txt"
+            save_table_potential(
+                    potential=smoothed_pot,
+                    r=angle.theta_range,
+                    dr=angle.dtheta,
+                    iteration=None,
+                    potential_file=file_name
+            )
 
     def optimize_pairs(
         self,

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -89,7 +89,7 @@ class MSIBI(object):
         self.gsd_period = gsd_period
         self.n_steps = n_steps
         self.max_frames = max_frames
-        self.nlist_exclusions = nlist_exclusion
+        self.nlist_exclusions = nlist_exclusions
         # Store all of the needed interaction objects
         self.states = []
         self.pairs = []

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -280,7 +280,7 @@ class MSIBI(object):
                         pair.dr,
                         iteration,
                         pair._potential_file
-                    )
+                )
 
         elif self.optimization == "bonds":
             for bond in self.bonds:
@@ -311,14 +311,20 @@ class MSIBI(object):
         for state in self.states:
             bond_object._compute_current_distribution(state)
             bond_object._save_current_distribution(state, iteration=iteration)
+            print("{0}, State: {1}, Iteration: {2}: {3:f}".format(
+                    bond_object.name,
+                    state.name,
+                    iteration,
+                    bond_object._states[state]["f_fit"][iteration]
+                )
+            )
 
     def _recompute_rdfs(self, pair, iteration):
         """Recompute the current RDFs for every state used for a given pair."""
         for state in self.states:
             pair._compute_current_rdf(state)
             pair._save_current_rdf(state, iteration=iteration)
-            print(
-                "pair {0}, state {1}, iteration {2}: {3:f}".format(
+            print("Pair: {0}, State: {1}, Iteration: {2}: {3:f}".format(
                     pair.name,
                     state.name,
                     iteration,
@@ -365,7 +371,7 @@ class MSIBI(object):
                         pair.dr,
                         iteration,
                         pair._potential_file
-                    )
+                )
 
         for bond in self.bonds:
             if bond.bond_type == "table" and bond._potential_file == "":
@@ -420,4 +426,3 @@ class MSIBI(object):
                 bonds=self.bonds,
                 angles=self.angles
             )
-

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -136,7 +136,7 @@ class MSIBI(object):
         self._initialize(potentials_dir=_dir)
 
         for n in range(start_iteration + n_iterations):
-            print(f"-------- Iteration {n} --------")
+            print(f"-------- Bond Optimization: Iteration {n} --------")
             run_query_simulations(self.states)
             self._update_potentials(n)
         # Save final potential
@@ -175,7 +175,7 @@ class MSIBI(object):
         self._initialize(potentials_dir=_dir)
 
         for n in range(start_iteration + n_iterations):
-            print(f"-------- Iteration {n} --------")
+            print(f"-------- Angle Optimization: Iteration {n} --------")
             run_query_simulations(self.states)
             self._update_potentials(n)
         # Save final potential
@@ -233,7 +233,7 @@ class MSIBI(object):
         self._initialize(potentials_dir=_dir)
 
         for n in range(start_iteration + n_iterations):
-            print(f"-------- Iteration {n} --------")
+            print(f"-------- Pair Optimization: Iteration {n} --------")
             run_query_simulations(self.states)
             self._update_potentials(n)
 

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -67,6 +67,8 @@ class State(object):
     def _save_runscript(
         self,
         n_steps,
+        nlist,
+        nlist_exclusions,
         integrator,
         integrator_kwargs,
         dt,
@@ -78,7 +80,7 @@ class State(object):
         """Save the input script for the MD engine."""
         script = list()
         script.append(
-            HOOMD2_HEADER.format(self.traj_file)
+            HOOMD2_HEADER.format(self.traj_file, nlist, nlist_exclusions)
         )
         if pairs is not None and len(pairs) > 0:
             if len(set([p.pair_init for p in pairs])) != 1:

--- a/msibi/tests/test_msibi.py
+++ b/msibi/tests/test_msibi.py
@@ -12,6 +12,7 @@ class TestMSIBI(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 max_frames=10,
@@ -27,6 +28,7 @@ class TestMSIBI(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 max_frames=10,
@@ -50,6 +52,7 @@ class TestMSIBI(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 max_frames=10,
@@ -69,6 +72,7 @@ class TestMSIBI(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 max_frames=10,

--- a/msibi/tests/test_pair.py
+++ b/msibi/tests/test_pair.py
@@ -37,6 +37,7 @@ class TestPair(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 max_frames=10,
@@ -62,6 +63,7 @@ class TestPair(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=5000,
                 n_steps=1e4,
@@ -86,6 +88,7 @@ class TestPair(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=5000,
                 n_steps=1e4,
@@ -109,6 +112,7 @@ class TestPair(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 n_steps=1e6,
@@ -138,6 +142,7 @@ class TestPair(BaseTest):
         opt = MSIBI(
                 integrator="hoomd.md.integrate.nvt",
                 integrator_kwargs={"tau": 0.1},
+                nlist="hoomd.md.nlist.cell",
                 dt=0.001,
                 gsd_period=1000,
                 max_frames=10,

--- a/msibi/tests/test_pair.py
+++ b/msibi/tests/test_pair.py
@@ -53,8 +53,8 @@ class TestPair(BaseTest):
                 _dir=tmp_path,
         )
         assert isinstance(pairs[0]._states, dict)
-        assert np.array_equal(pairs[3]._states[state0]["target_rdf"], rdf0)
-        assert pairs[3]._states[state0]["current_rdf"] is None
+        assert np.array_equal(pairs[3]._states[state0]["target_distribution"], rdf0)
+        assert pairs[3]._states[state0]["current_distribution"] is None
         assert pairs[3]._states[state0]["alpha"] == 0.5
         assert len(pairs[3]._states[state0]["f_fit"]) == 0
     
@@ -80,7 +80,7 @@ class TestPair(BaseTest):
                 _dir=tmp_path,
             )
         pairs[3]._compute_current_rdf(state0)
-        assert pairs[3]._states[state0]["current_rdf"] is not None
+        assert pairs[3]._states[state0]["current_distribution"] is not None
         assert len(pairs[3]._states[state0]["f_fit"]) > 0
 
     @pytest.mark.skip(reason="Need better test GSDs before running IBI in tests")
@@ -105,7 +105,7 @@ class TestPair(BaseTest):
                 _dir=tmp_path,
             )
         pairs[3]._compute_current_rdf(state0)
-        assert pairs[3]._states[state0]["current_rdf"] is not None
+        assert pairs[3]._states[state0]["current_distribution"] is not None
         assert len(pairs[3]._states[state0]["f_fit"]) > 0
 
     def test_save_current_rdf(self, state0, pairs, tmp_path):
@@ -128,8 +128,8 @@ class TestPair(BaseTest):
                 smooth_rdfs=True,
                 _dir=tmp_path,
             )
-        target_rdf = pairs[0]._states[state0]["target_rdf"]
-        pairs[0]._states[state0]["current_rdf"] = target_rdf 
+        target_rdf = pairs[0]._states[state0]["target_distribution"]
+        pairs[0]._states[state0]["current_distribution"] = target_rdf 
         pairs[0]._save_current_rdf(state0, 0)
         assert os.path.isfile(
             os.path.join(
@@ -158,7 +158,7 @@ class TestPair(BaseTest):
                 smooth_rdfs=True,
                 _dir=tmp_path,
             )
-        target_rdf = pairs[1]._states[state0]["target_rdf"]
-        pairs[0]._states[state0]["current_rdf"] = target_rdf
+        target_rdf = pairs[1]._states[state0]["target_distribution"]
+        pairs[0]._states[state0]["current_distribution"] = target_rdf
         pairs[0]._update_potential()
         assert not np.array_equal(pairs[0].potential, pairs[0].previous_potential)

--- a/msibi/utils/hoomd_run_template.py
+++ b/msibi/utils/hoomd_run_template.py
@@ -6,8 +6,8 @@ from hoomd.init import read_gsd
 hoomd.context.initialize("")
 system = read_gsd("{0}", frame=-1, time_step=0)
 
-nl = hoomd.md.nlist.cell()
-nl.reset_exclusions(exclusions=["1-2", "1-3", "1-4"])
+nl = {1}()
+nl.reset_exclusions(exclusions={2})
 """
 
 HOOMD_TEMPLATE = """


### PR DESCRIPTION
This PR adds a few things:

- neighbor lists type can be set in the MSIBI class
- Pair exclusions can be set in the MSIBI class
- The final potentials are smoothed and saved in a separate file
- Renamed some variables for better consistency
- Saves the target distributions to a file as well as the iterations and final distributions.
- Closes #23 