### PR TITLE
Add more documentation, rework hoomd force obj creation, add methods to save potential table files and pickle forcefields

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - gsd >=3.0
 - hoomd >=4.0
 - python >=3.9
+- pandas
 - cmeutils >=1.2
 - more-itertools
 - jupyter

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,11 @@ name: msibi
 channels:
 - conda-forge
 dependencies:
-- cuda-version==11.8
-- freud>=2.13
-- gsd>=3.0
-- hoomd>=4.0
-- cmeutils
+- cuda-version=11.8
+- freud >=2.13
+- gsd >=3.0
+- hoomd >=4.0
+- python >=3.9
+- cmeutils >=1.2
 - more-itertools
 - jupyter

--- a/msibi/__init__.py
+++ b/msibi/__init__.py
@@ -1,9 +1,9 @@
-from msibi.optimize import MSIBI
-from msibi.forces import Pair, Bond, Angle, Dihedral
-from msibi.potentials import *
-from msibi.state import State
-from msibi.__version__ import __version__
-from msibi import utils
+from .state import State
+from .forces import Pair, Bond, Angle, Dihedral
+from .optimize import MSIBI
+from .potentials import *
+from .__version__ import __version__
+from . import utils
 
 __all__ = [
     "__version__",

--- a/msibi/__init__.py
+++ b/msibi/__init__.py
@@ -1,7 +1,8 @@
 from .state import State
 from .forces import Pair, Bond, Angle, Dihedral
 from .optimize import MSIBI
-from .potentials import *
+#from .potentials import *
+#from .potentials import quadratic_spring, mie, lennard_jones, pair_tail_correction 
 from .__version__ import __version__
 from . import utils
 

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -847,7 +847,6 @@ class Pair(Force):
                 "r_min": self.x_min,
                 "U": self.potential,
                 "F": self.force,
-                "r_cut": self.r_cut
         }
         return table_entry
 

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -91,10 +91,7 @@ class Force(object):
 
     @property
     def potential(self) -> np.ndarray:
-        """
-        The potential energy values V(x).
-
-        """
+        """The potential energy values V(x)."""
         if self.format != "table":
             warnings.warn(f"{self} is not using a table potential.")
         return self._potential
@@ -113,11 +110,7 @@ class Force(object):
 
     @property
     def force(self) -> np.ndarray:
-        """
-        The force values F(x).
-
-        """
-
+        """The force values F(x)."""
         if self.format != "table":
             warnings.warn(f"{self} is not using a table potential.")
             return None
@@ -125,11 +118,7 @@ class Force(object):
 
     @property
     def smoothing_window(self) -> int:
-        """
-        Window size used in smoothing the distributions.
-
-        """
-
+        """Window size used in smoothing the distributions."""
         return self._smoothing_window
 
     @smoothing_window.setter
@@ -140,9 +129,7 @@ class Force(object):
 
     @property
     def smoothing_order(self) -> int:
-        """
-        The order used in smoothing the distributions.
-        """
+        """The order used in smoothing the distributions."""
         return self._smoothing_order
 
     @smoothing_order.setter
@@ -153,10 +140,7 @@ class Force(object):
 
     @property
     def nbins(self) -> int:
-        """
-        The number of bins used in calculating distributions.
-
-        """
+        """The number of bins used in calculating distributions."""
         return self._nbins
 
     @nbins.setter
@@ -166,8 +150,7 @@ class Force(object):
             self._add_state(state)
 
     def target_distribution(self, state: msibi.state.State) -> np.ndarray:
-        """
-        The target structural distribution corresponding to this foce.
+        """The target structural distribution corresponding to this foce.
 
         Parameters
         ----------
@@ -175,7 +158,6 @@ class Force(object):
             The state to use in finding the target distribution.
 
         """
-
         return self._states[state]["target_distribution"]
 
     def plot_target_distribution(self, state: msibi.state.State) -> None:
@@ -195,7 +177,6 @@ class Force(object):
         and smoothing order.
 
         """
-
         #TODO: Make custom error
         if not self.optimize:
             raise RuntimeError(
@@ -218,8 +199,7 @@ class Force(object):
             plt.legend()
 
     def plot_fit_scores(self, state: msibi.state.State) -> None:
-       """
-       Plots the evolution of the distribution
+       """Plots the evolution of the distribution
        matching evolution.
 
         Parameters
@@ -228,7 +208,6 @@ class Force(object):
             The state to use in finding the target distribution.
 
        """
-
        if not self.optimize:
             raise RuntimeError("This force object is not set to be optimized.")
        fig = plt.figure()
@@ -237,8 +216,7 @@ class Force(object):
        plt.ylabel("Fit Score")
 
     def distribution_history(self, state: msibi.state.State):
-        """
-        Returns the complete query distribution history for a given state.
+        """Get the complete query distribution history for a given state.
 
         Parameters
         ----------
@@ -246,12 +224,10 @@ class Force(object):
             The state to use for calculating the distribution.
 
         """
-
         return self._states[state]["distribution_history"]
 
     def set_target_distribution(self, state: msibi.state.State, array) -> None:
-        """
-        Stores the target distribution for a given state.
+        """Store the target distribution for a given state.
 
         Parameters
         ----------
@@ -266,8 +242,7 @@ class Force(object):
             state: msibi.state.State,
             query: bool=True
     ) -> np.ndarray:
-        """
-        Returns the corresponding distrubution from the most recent
+        """Returns the corresponding distrubution from the most recent
         query simulation.
 
         Parameters
@@ -276,12 +251,10 @@ class Force(object):
             The state to use for calculating the distribution.
 
         """
-
         return self._get_state_distribution(state, query)
 
     def distribution_fit(self, state: msibi.state.State) -> float:
-        """
-        Returns the fit score from the most recent query simulation.
+        """Get the fit score from the most recent query simulation.
 
         Parameters
         ----------
@@ -289,7 +262,6 @@ class Force(object):
             The state to use for calculating the distribution.
 
         """
-
         return self._calc_fit(state)
 
     def set_quadratic(
@@ -301,8 +273,7 @@ class Force(object):
             x_min: Union[float, int],
             x_max: Union[float, int]
     ) -> None:
-        """
-        Set a potential based on the following function:
+        """Set a potential based on the following function:
 
             V(x) = k4(x-x0)^4 + k3(x-x0)^3 + k2(x-x0)^2
 
@@ -320,6 +291,7 @@ class Force(object):
             The lower bound of the potential range
         x_max : float, required
             The upper bound of the potential range
+
         """
         self.format = "table"
         self.x_min = x_min
@@ -331,27 +303,26 @@ class Force(object):
         self.force_entry = self._table_entry()
 
     def set_from_file(self, file_path: str) -> None:
-        """
-        Set a potential from a text file.
-        The columns of the text file must be in the order of r, V.
-        where r is the independent value (i.e. distance) and V
-        is the potential enregy at r. The force will be calculated
-        from r and V using np.gradient().
+        """Set a potential from a text file.
 
         Parameters:
         -----------
         file_path : str, required
             The full path to the table potential text file.
 
-        Notes
-        -----
+        Notes:
+        ------
+        The columns of the text file must be in the order of r, V.
+        where r is the independent value (i.e. distance) and V
+        is the potential enregy at r. The force will be calculated
+        from r and V using np.gradient().
+
         Use this potential setter to set a potential from a previous MSIBI run.
         For example, use the final potential files from a bond-optimization IBI
         run to set a static coarse-grained bond potential while you perform
         IBI runs on angle and/or pair potentials.
 
         """
-
         f = np.loadtxt(file_path)
         self.x_range = f[:,0]
         self.dx = np.round(self.x_range[1] - self.x_range[0], 3)
@@ -363,8 +334,7 @@ class Force(object):
         self.force_entry = self.table_entry()
 
     def _add_state(self, state: msibi.state.State) -> None:
-        """
-        Add a state to be used in optimizing this force.
+        """Add a state to be used in optimizing this force.
 
         Parameters
         ----------
@@ -397,8 +367,7 @@ class Force(object):
         }
 
     def _compute_current_distribution(self, state: msibi.state.State) -> None:
-        """
-        Find the current distribution of the query trajectory
+        """Find the current distribution of the query trajectory
 
         Parameters
         ----------
@@ -406,7 +375,6 @@ class Force(object):
             Instance of a State object previously created.
 
         """
-
         distribution = self._get_state_distribution(state, query=True)
         if self.smoothing_window and self.smoothing_order:
             distribution[:,1] = savitzky_golay(
@@ -431,8 +399,7 @@ class Force(object):
             state: msibi.state.State,
             query: bool
     ) -> np.ndarray:
-        """
-        Get the corresponding distrubiton for a given state.
+        """Get the corresponding distrubiton for a given state.
 
         Parameters
         ----------
@@ -443,7 +410,6 @@ class Force(object):
             If False, uses the state's target trajectory.
 
         """
-
         if query:
             traj = state.query_traj
         else:
@@ -455,8 +421,7 @@ class Force(object):
             state: msibi.state.State,
             iteration: int
     ) -> None:
-        """
-        Save the corresponding distrubiton for a given state to a file.
+        """Save the corresponding distrubiton for a given state to a file.
 
         Parameters
         ----------
@@ -466,7 +431,6 @@ class Force(object):
             Current iteration step, used in the filename.
 
         """
-
         distribution = self._states[state]["current_distribution"]
         distribution[:,0] -= self.dx / 2
         fname = f"dist_{self.name}-state_{state.name}-step_{iteration}.txt"
@@ -474,12 +438,10 @@ class Force(object):
         np.savetxt(fpath, distribution)
 
     def _update_potential(self) -> None:
-        """
-        Compare distributions of current iteration against target,
+        """Compare distributions of current iteration against target,
         and update the potential via Boltzmann inversion.
 
         """
-
         self.potential_history.append(np.copy(self.potential))
         for state in self._states:
             kT = state.kT
@@ -523,8 +485,7 @@ class Bond(Force):
         )
 
     def set_harmonic(self, r0: Union[float, int], k: Union[float, int]) -> None:
-        """
-        Set a fixed harmonic bond potential.
+        """Set a fixed harmonic bond potential.
         Using this method is not compatible force msibi.forces.Force
         objects that are set to be optimized during MSIBI
 
@@ -561,8 +522,7 @@ class Bond(Force):
             state: msibi.state.State,
             gsd_file: str
     ) -> np.ndarray:
-        """
-        Calculate a bond length distribution.
+        """Calculate a bond length distribution.
 
         Parameters
         ----------
@@ -608,8 +568,7 @@ class Angle(Force):
         )
 
     def set_harmonic(self, t0: Union[float, int], k: Union[float, int]) -> None:
-        """
-        Set a fixed harmonic angle potential.
+        """Set a fixed harmonic angle potential.
         Using this method is not compatible force msibi.forces.Force
         objects that are set to be optimized during MSIBI
 
@@ -621,7 +580,6 @@ class Angle(Force):
             Spring constant
 
         """
-
         if self.optimize:
             raise RuntimeError(
                     f"Force {self} is set to be optimized during MSIBI."
@@ -642,8 +600,7 @@ class Angle(Force):
             state: msibi.state.State,
             gsd_file: str
     ) -> np.ndarray:
-        """
-        Calculate a bond angle distribution.
+        """Calculate a bond angle distribution.
 
         Parameters
         ----------
@@ -692,8 +649,7 @@ class Pair(Force):
             epsilon: Union[float, int],
             sigma: Union[float, int]
     ) -> None:
-        """
-        Set a hoomd 12-6 LJ pair potential used during
+        """Set a hoomd 12-6 LJ pair potential used during
         the query simulations.
 
         Parameters
@@ -715,8 +671,7 @@ class Pair(Force):
             state: msibi.state.State,
             gsd_file: str
     ) -> np.ndarray:
-        """
-        Calculate a pair distribution.
+        """Calculate a pair distribution.
 
         Parameters
         ----------
@@ -767,8 +722,7 @@ class Dihedral(Force):
             d: int,
             n: int,
     ) -> None:
-        """
-        Set a fixed harmonic dihedral potential.
+        """Set a fixed harmonic dihedral potential.
 
         Parameters
         ----------
@@ -802,8 +756,7 @@ class Dihedral(Force):
             state: msibi.state.State,
             gsd_file: str
     ) -> np.ndarray:
-        """
-        Calculate a dihedral distribution.
+        """Calculate a dihedral distribution.
 
         Parameters
         ----------

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -833,6 +833,8 @@ class Pair(Force):
         self.format = "table"
         self.dx = (r_cut - r_min) / self.nbins
         self.x_range = np.arange(r_min, r_cut + self.dx, self.dx)
+        self.x_min = self.x_range[0]
+        self.r_cut = self.x_range[-1]
         self.potential = lennard_jones(
                 r=self.x_range,
                 epsilon=epsilon,
@@ -864,14 +866,22 @@ class Pair(Force):
             Path to the GSD file used.
 
         """
-        return gsd_rdf(
-                gsdfile=gsd_file,
-                A_name=self.type1,
-                B_name=self.type2,
-                start=-state.n_frames,
-                stop=-1,
-                bins=self.nbins + 1
+        rdf, N = gsd_rdf(
+                    gsdfile=gsd_file,
+                    A_name=self.type1,
+                    B_name=self.type2,
+                    r_min=self.x_min,
+                    r_max=self.r_cut,
+                    exclude_bonded=state.exclude_bonded,
+                    start=-state.n_frames,
+                    stop=-1,
+                    bins=self.nbins + 1
         )
+        x = rdf.bin_centers
+        y = rdf.rdf * N
+        dist = np.vstack([x, y])
+        return dist.T
+
 
 
 class Dihedral(Force):

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -165,7 +165,7 @@ class Force(object):
         ----
         This uses a Savitzky Golay smoothing algorithm where the
         window size and order parameters are set by
-        msibi.forces.Force.smoothing_window and 
+        msibi.forces.Force.smoothing_window and
         msibi.forces.Force.smoothing_order.
         Both of these can be changed using their respective setters.
 
@@ -176,7 +176,7 @@ class Force(object):
             )
         potential = np.copy(self.potential)
         self.potential = savitzky_golay(
-                y=potential, 
+                y=potential,
                 window_size=self.smoothing_window,
                 order=self.smoothing_order,
         )
@@ -187,7 +187,7 @@ class Force(object):
         Parameters
         ----------
         file_path : str, required
-            File path and name to save table potential to. 
+            File path and name to save table potential to.
 
         Notes
         -----
@@ -385,14 +385,13 @@ class Force(object):
         Also see: msibi.forces.Force.save_potential()
 
         """
+        self.format = "table"
         df = pd.read_csv(file_path)
         self.x_range = df["x"].values
         self.potential = df["potential"].values
-        self.x_range = f[:,0]
         self.dx = np.round(self.x_range[1] - self.x_range[0], 3)
         self.x_min = self.x_range[0]
         self.x_max = self.x_range[-1] + self.dx
-        self.format = "table"
         self.force_init = "Table"
 
     def _add_state(self, state: msibi.state.State) -> None:
@@ -831,13 +830,7 @@ class Pair(Force):
             Maximum distance used to calculate neighbor pair potentials.
 
         """
-        if self.optimize:
-            raise RuntimeError(
-                    f"Force {self} is set to be optimized during MSIBI."
-                    "This potential setter cannot be used "
-                    "for a force designated for optimization. "
-                    "Instead, use set_from_file() or set_quadratic()."
-            ) 
+        self.format = "table"
         self.dx = (r_cut - r_min) / self.nbins
         self.x_range = np.arange(r_min, r_cut + self.dx, self.dx)
         self.potential = lennard_jones(
@@ -845,9 +838,7 @@ class Pair(Force):
                 epsilon=epsilon,
                 sigma=sigma
         )
-        self.type = "static"
-        self.force_init = "LJ"
-        self.force_entry = dict(sigma=sigma, epsilon=epsilon, r_cut=self.r_cut)
+        self.force_init = "Table"
 
     def _table_entry(self) -> dict:
         table_entry = {

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -12,6 +12,7 @@ from cmeutils.structure import (
 import matplotlib.pyplot as plt
 import numpy as np
 
+import msibi
 from msibi.potentials import quadratic_spring, bond_correction
 from msibi.utils.error_calculation import calc_similarity
 from msibi.utils.smoothing import savitzky_golay
@@ -264,7 +265,7 @@ class Force(object):
             self,
             state: msibi.state.State,
             query: bool=True
-    ) --> np.ndarray:
+    ) -> np.ndarray:
         """
         Returns the corresponding distrubution from the most recent
         query simulation.
@@ -762,9 +763,9 @@ class Dihedral(Force):
     def set_harmonic(
             self,
             phi0: Union[float, int],
-            k: Union[float, int]
-            d: int
-            n: int
+            k: Union[float, int],
+            d: int,
+            n: int,
     ) -> None:
         """
         Set a fixed harmonic dihedral potential.
@@ -796,7 +797,7 @@ class Dihedral(Force):
         table_entry = {"U": self.potential, "tau": self.force}
         return table_entry
 
-    def _get_distribution(:
+    def _get_distribution(
             self,
             state: msibi.state.State,
             gsd_file: str

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -636,6 +636,9 @@ class Pair(Force):
     ):
         self.type1, self.type2 = sorted( [type1, type2], key=natural_sort)
         name = f"{self.type1}-{self.type2}"
+        # Pair types have different naming structure than bonds, angles, etc..
+        self._pair_name = (type1, type2)
+        #TODO: Set r_cut in pair class
         self.r_cut = None
         super(Pair, self).__init__(
                 name=name,
@@ -643,7 +646,7 @@ class Pair(Force):
                 nbins=nbins,
                 head_correction_form=head_correction_form
         )
-
+    #TODO: need table entry method for pairs
     def set_lj(
             self,
             epsilon: Union[float, int],

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -157,6 +157,55 @@ class Force(object):
         for state in self._states:
             self._add_state(state)
 
+    def smooth_potential(self) -> None:
+        """Smooth and overwrite the current potential.
+
+        Note
+        ----
+        This uses a Savitzky Golay smoothing algorithm where the
+        window size and order parameters are set by
+        msibi.forces.Force.smoothing_window and 
+        msibi.forces.Force.smoothing_order.
+        Both of these can be changed using their respective setters.
+
+        """
+        if self.format != "table":
+            raise RuntimeError(
+                    "This force is not a table potential and is not mutable."
+            )
+        potential = np.copy(self.potential)
+        self.potential = savitzky_golay(
+                y=potential, 
+                window_size=self.smoothing_window,
+                order=self.smoothing_order,
+        )
+
+    def save_potential(self, file_path: str) -> None:
+        """Save the x-range, potential and force to file.
+
+        Parameters
+        ----------
+        file_path : str, required
+            File path and name to save table potential to. 
+
+        Notes
+        -----
+        This method uses numpy.savetxt and saves the data
+        in the order of x, V(x), F(x).
+
+        If you want to smooth the final potential, use
+        msibi.forces.Force.smooth_potential() before
+        calling this method.
+
+        """
+        if self.format != "table":
+            raise RuntimeError(
+                    "This force is not a table potential and "
+                    "cannot be saved to a .txt file."
+            )
+        data = np.vstack([self.x_range, self.potential, self.force])
+        np.savetxt(file_path, data.T)
+
     def target_distribution(self, state: msibi.state.State) -> np.ndarray:
         """The target structural distribution corresponding to this foce.
 

--- a/msibi/forces.py
+++ b/msibi/forces.py
@@ -134,12 +134,12 @@ class Force(object):
     @property
     def smoothing_order(self) -> int:
         """The order used in smoothing the distributions."""
-        if not isinstance(value, int):
-            raise ValueError("The smoothing order must be an integer.")
         return self._smoothing_order
 
     @smoothing_order.setter
     def smoothing_order(self, value: int):
+        if not isinstance(value, int):
+            raise ValueError("The smoothing order must be an integer.")
         self._smoothing_order = value
         for state in self._states:
             self._add_state(state)
@@ -540,7 +540,7 @@ class Bond(Force):
             raise RuntimeError(
                     f"Force {self} is set to be optimized during MSIBI."
                     "This potential setter cannot be used "
-                    "for a force designated for optimization. " 
+                    "for a force designated for optimization. "
                     "Instead, use set_from_file() or set_quadratic()."
             )
         self.type = "static"
@@ -655,7 +655,7 @@ class Angle(Force):
             raise RuntimeError(
                     f"Force {self} is set to be optimized during MSIBI."
                     "This potential setter cannot be used "
-                    "for a force designated for optimization. " 
+                    "for a force designated for optimization. "
                     "Instead, use set_from_file() or set_quadratic()."
             )
         self.type = "static"
@@ -727,7 +727,7 @@ class Pair(Force):
     Notes
     -----
     The pair type is sorted so that type1 and type2
-    are listed in alphabetical order, and must match the pair 
+    are listed in alphabetical order, and must match the pair
     types found in the state's target GSD file bond types.
 
     For example: `Pair(type1="B", type2="A")` will have `Pair.name = "A-B"`
@@ -739,13 +739,13 @@ class Pair(Force):
             type1: str,
             type2: str,
             optimize: bool,
-            r_cut: Union[int, float]
+            r_cut: Union[float, int],
             nbins: int=None,
             exclude_bonded: bool=False,
             head_correction_form: str="linear"
     ):
         self.type1, self.type2 = sorted( [type1, type2], key=natural_sort)
-        self.r_cut = r_cut 
+        self.r_cut = r_cut
         name = f"{self.type1}-{self.type2}"
         # Pair types in hoomd have different naming structure.
         self._pair_name = (type1, type2)
@@ -778,7 +778,7 @@ class Pair(Force):
             raise RuntimeError(
                     f"Force {self} is set to be optimized during MSIBI."
                     "This potential setter cannot be used "
-                    "for a force designated for optimization. " 
+                    "for a force designated for optimization. "
                     "Instead, use set_from_file() or set_quadratic()."
             )
         self.type = "static"
@@ -902,7 +902,7 @@ class Dihedral(Force):
             raise RuntimeError(
                     f"Force {self} is set to be optimized during MSIBI."
                     "This potential setter cannot be used "
-                    "for a force designated for optimization. " 
+                    "for a force designated for optimization. "
                     "Instead, use set_from_file() or set_quadratic()."
             )
         self.type = "static"

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -73,11 +73,11 @@ class MSIBI(object):
             thermostat,
             method_kwargs,
             thermostat_kwargs,
-            dt,
-            gsd_period,
+            dt: float,
+            gsd_period: int,
             r_cut,
-            nlist_exclusions=["bond", "angle"],
-            seed=42,
+            nlist_exclusions: list[str]=["bond", "angle"],
+            seed: int=42,
     ):
         if nlist not in ["Cell", "Tree", "Stencil"]:
             raise ValueError(f"{nlist} is not a valid neighbor list in Hoomd")
@@ -96,7 +96,7 @@ class MSIBI(object):
         self.forces = []
         self._optimize_forces = []
 
-    def add_state(self, state):
+    def add_state(self, state: msibi.state.State) -> None:
         """Add a state point to MSIBI.states.
 
         Parameters
@@ -107,7 +107,7 @@ class MSIBI(object):
         state._opt = self
         self.states.append(state)
 
-    def add_force(self, force):
+    def add_force(self, force: msibi.forces.Force) -> None:
         """Add a force to be included in the query simulations.
 
         Parameters
@@ -158,11 +158,11 @@ class MSIBI(object):
 
     def run_optimization(
             self,
-            n_steps,
-            n_iterations,
-            backup_trajectories=False,
+            n_steps: int,
+            n_iterations: int,
+            backup_trajectories: bool=False,
             _dir=None
-    ):
+    ) -> None:
         """Runs query simulations and performs MSIBI
         on the potentials set to be optimized.
 
@@ -203,13 +203,31 @@ class MSIBI(object):
             self._update_potentials()
             self.n_iterations += 1
 
+    def pickle_forcefield(self, file_path: str) -> None:
+        """
+        Save the Hoomd objects for all forces to a single pickle file.
+
+        Parameters
+        ----------
+        file_path : str, required
+            The path and file name for the pickle file.
+
+        Notes
+        -----
+        Use this method as a convienent way to use the final
+        set of forces in your own Hoomd-Blue script, or with
+        flowerMD (https://github.com/cmelab/flowerMD)
+
+        """
+
+
     def _update_potentials(self):
         """Update the potentials for the potentials to be optimized."""
         for force in self._optimize_forces:
             self._recompute_distribution(force)
             force._update_potential()
 
-    def _recompute_distribution(self, force):
+    def _recompute_distribution(self, force: msibi.forces.Force) -> None:
         """Recompute the current distribution of bond lengths or angles"""
         for state in self.states:
             force._compute_current_distribution(state)

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -68,8 +68,8 @@ class MSIBI(object):
     def __init__(
             self,
             nlist: hoomd.md.nlist,
-            integrator_method hoomd.md.methods,
-            thermostat: hoomd.md.methods.thermostats,
+            integrator_method: hoomd.md.methods.Method,
+            thermostat: hoomd.md.methods.thermostats.Thermostat,
             method_kwargs: dict,
             thermostat_kwargs: dict,
             dt: float,
@@ -77,10 +77,10 @@ class MSIBI(object):
             nlist_exclusions: list[str]=["bond", "angle"],
             seed: int=42,
     ):
-        if (
-                not isinstance(integrator_method, ConstantVolume) or
-                not isinstance(integrator_method, ConstantPressure)
-        ):
+        if integrator_method not in [
+                hoomd.md.methods.ConstantVolume,
+                hoomd.md.methods.ConstantPressure
+        ]:
             raise ValueError(
                     "MSIBI is only compatible with NVT "
                     "(hoomd.md.methods.ConstantVolume), or NPT "
@@ -185,7 +185,7 @@ class MSIBI(object):
         """
         for n in range(n_iterations):
             print(f"---Optimization: {n+1} of {n_iterations}---")
-            forces = self._build_objects()
+            forces = self._build_force_objects()
             for state in self.states:
                 state._run_simulation(
                     n_steps=n_steps,
@@ -225,8 +225,8 @@ class MSIBI(object):
             )
         f = open(file_path, "wb")
         pickle.dump(forces, f)
-    
-    def _build_foce_objects(self) -> list:
+
+    def _build_force_objects(self) -> list:
         """Creates force objects for query simulations."""
         nlist = getattr(hoomd.md.nlist, self.nlist)
         # Create pair objects

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -228,7 +228,6 @@ class MSIBI(object):
 
     def _build_force_objects(self) -> list:
         """Creates force objects for query simulations."""
-        nlist = getattr(hoomd.md.nlist, self.nlist)
         # Create pair objects
         pair_force = None
         for pair in self.pairs:
@@ -238,7 +237,7 @@ class MSIBI(object):
                     pair_force = hoomd_pair_force(width=pair.nbins)
                 else:
                     pair_force = hoomd_pair_force(
-                            nlist=nlist(
+                            nlist=self.nlist(
                                 buffer=20,
                                 exclusions=self.nlist_exclusions
                             ),

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -7,7 +7,8 @@ import msibi
 
 
 class MSIBI(object):
-    """Management class for orchestrating an MSIBI optimization.
+    """
+    Management class for orchestrating an MSIBI optimization.
 
     Parameters
     ----------
@@ -56,13 +57,15 @@ class MSIBI(object):
     Methods
     -------
     add_state(msibi.state.state)
+        Add a state point to be included in optimizing forces.
     add_force(msibi.forces.Force)
         Add the required interaction objects. See forces.py
-    run_optimization(n_iterations, backup_trajectories)
+    run_optimization(n_iterations, n_steps, backup_trajectories)
         Performs iterations of query simulations and potential updates
         resulting in a final optimized potential.
 
     """
+
     def __init__(
             self,
             nlist,
@@ -101,11 +104,13 @@ class MSIBI(object):
         state : msibi.state.State, required
             Instance of msibi.state.State
         """
+        #TODO: Do we need this?
         state._opt = self
         self.states.append(state)
 
     def add_force(self, force: msibi.forces.Force) -> None:
-        """Add a force to be included in the query simulations.
+        """
+        Add a force to be included in the query simulations.
 
         Parameters
         ----------
@@ -116,6 +121,7 @@ class MSIBI(object):
         -----
         Only one type of force can be optimized at a time.
         Forces not set to be optimized are held fixed during query simulations.
+
         """
         self.forces.append(force)
         if force.optimize:

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -4,9 +4,6 @@ import shutil
 import numpy as np
 
 import msibi
-from msibi.potentials import pair_tail_correction, save_table_potential
-from msibi.utils.smoothing import savitzky_golay
-from msibi.utils.exceptions import UnsupportedEngine
 
 
 class MSIBI(object):

--- a/msibi/optimize.py
+++ b/msibi/optimize.py
@@ -234,7 +234,12 @@ class MSIBI(object):
             if not pair_force: # Only create hoomd.md.pair obj once
                 hoomd_pair_force = getattr(hoomd.md.pair, pair.force_init)
                 if pair.force_init == "Table":
-                    pair_force = hoomd_pair_force(width=pair.nbins)
+                    pair_force = hoomd_pair_force(
+                            nlist=self.nlist(
+                                buffer=20,
+                                exclusions=self.nlist_exclusions
+                            ),
+                    )
                 else:
                     pair_force = hoomd_pair_force(
                             nlist=self.nlist(
@@ -244,6 +249,7 @@ class MSIBI(object):
                     )
             if pair.format == "table":
                 pair_force.params[pair._pair_name] = pair._table_entry()
+                pair_force.r_cut[pair._pair_name] = pair.r_cut
             else:
                 pair_force.params[pair._pair_name] = pair.force_entry
         # Create bond objects

--- a/msibi/potentials.py
+++ b/msibi/potentials.py
@@ -5,22 +5,6 @@ import numpy as np
 
 from msibi.utils.general import find_nearest
 
-#TODO: Move this to the Force class
-def save_table_potential(potential, r, dr, iteration, potential_file):
-    """Save the length, potential energy,force values to a text file."""
-    F = -1.0 * np.gradient(potential, dr)
-    data = np.vstack([r, potential, F])
-    # This file overwritten for each iteration, used during query sim.
-    np.savetxt(potential_file, data.T)
-
-    if iteration != None:
-        basename = os.path.basename(potential_file)
-        basename = "step{0:d}.{1}".format(iteration, basename)
-        dirname = os.path.dirname(potential_file)
-        iteration_filename = os.path.join(dirname, basename)
-        # This file written for viewing evolution of potential.
-        np.savetxt(iteration_filename, data.T)
-
 
 def quadratic_spring(x, x0, k4, k3, k2):
     """Creates a quadratic spring-like potential with the following form
@@ -38,7 +22,11 @@ def mie(r, epsilon, sigma, m, n):
     """The Mie potential functional form"""
     prefactor = (m / (m - n)) * (m / n) ** (n / (m - n))
     V_r = prefactor * epsilon * ((sigma / r) ** m - (sigma / r) ** n)
-    return V_r 
+    return V_r
+
+
+def lennard_jones(r, epsilon, sigma):
+    return mie(r=r, epsilon=epsilon, sigma=sigma, m=12, n=6)
 
 
 def pair_tail_correction(r, V, r_switch):

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -114,10 +114,10 @@ class State(object):
             last_snap = traj[-1]
         sim.create_state_from_snapshot(last_snap)
         integrator = hoomd.md.Integrator(dt=dt)
-        integrator.forces = forces 
+        integrator.forces = forces
         thermostat = thermostat(kT=self.kT, **thermostat_kwargs)
         integrator.methods.append(
-                method(
+                integrator_method(
                     filter=hoomd.filter.All(),
                     thermostat=thermostat,
                     **method_kwargs

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -44,13 +44,12 @@ class State(object):
 
     def __init__(
         self,
-        name,
-        kT,
-        traj_file,
-        n_frames,
-        alpha=1.0,
-        exclude_bonded=True,
-        target_frames=None,
+        name: str,
+        kT: float,
+        traj_file: str,
+        n_frames: int,
+        alpha: float=1.0,
+        exclude_bonded: bool=True,
         _dir=None
     ):
         self.name = name
@@ -76,7 +75,7 @@ class State(object):
         return self._n_frames
 
     @n_frames.setter
-    def n_frames(self, value):
+    def n_frames(self, value: int):
         self._n_frames = value
 
     @property
@@ -84,7 +83,7 @@ class State(object):
         return self._alpha
 
     @alpha.setter
-    def alpha(self, value):
+    def alpha(self, value: float):
         self._alpha = value
 
     def _run_simulation(
@@ -106,7 +105,7 @@ class State(object):
             angles=None,
             dihedrals=None,
             backup_trajectories=False
-    ):
+    ) -> None:
         """
         Contains the hoomd 4 script used to run each query simulation.
         This method is called in msibi.optimize.

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from typing import Union
 import warnings
 
 
@@ -9,7 +10,8 @@ import hoomd
 
 
 class State(object):
-    """A single state used as part of a multistate optimization.
+    """
+    A single state used as part of a multistate optimization.
 
     Parameters
     ----------
@@ -70,7 +72,8 @@ class State(object):
         )
 
     @property
-    def n_frames(self):
+    def n_frames(self) -> int:
+        """The number of frames used in calculating distributions."""
         return self._n_frames
 
     @n_frames.setter
@@ -78,7 +81,8 @@ class State(object):
         self._n_frames = value
 
     @property
-    def alpha(self):
+    def alpha(self) -> Union[int, float]:
+        """State point weighting value."""
         return self._alpha
 
     @alpha.setter
@@ -105,12 +109,10 @@ class State(object):
             dihedrals=None,
             backup_trajectories=False
     ) -> None:
-        """
-        Contains the hoomd 4 script used to run each query simulation.
+        """Run the hoomd 4 script used to run each query simulation.
         This method is called in msibi.optimize.
 
         """
-
         device = hoomd.device.auto_select()
         sim = hoomd.simulation.Simulation(device=device)
         print(f"Starting simulation {iteration} for state {self}")

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -3,8 +3,6 @@ import shutil
 from typing import Union
 import warnings
 
-
-import gsd
 import gsd.hoomd
 import hoomd
 
@@ -17,14 +15,14 @@ class State(object):
     ----------
     name : str
         State name used in creating state directory space and output files.
-    kT : float
+    kT : (Union[float, int])
         Unitless heat energy (product of Boltzmann's constant and temperature).
-    traj_file : path to a gsd.hoomd.HOOMDTrajectory file
+    traj_file : path to a gsd.hoomd file
         The gsd trajectory associated with this state.
-        This trajectory is used to calcualte the target distributions used
+        This trajectory calcualtes the target distributions used
         during optimization.
-    alpha : float, default 1.0
-        The alpha value used to scaale the weight of this state.
+    alpha : (Union[float, int]), default 1.0
+        The alpha value used to scale the weight of this state.
 
     Attributes
     ----------
@@ -117,9 +115,7 @@ class State(object):
         sim.create_state_from_snapshot(last_snap)
         integrator = hoomd.md.Integrator(dt=dt)
         integrator.forces = forces 
-        _thermostat = getattr(hoomd.md.methods.thermostats, thermostat)
-        thermostat = _thermostat(kT=self.kT, **thermostat_kwargs)
-        method = getattr(hoomd.md.methods, integrator_method)
+        thermostat = thermostat(kT=self.kT, **thermostat_kwargs)
         integrator.methods.append(
                 method(
                     filter=hoomd.filter.All(),
@@ -146,7 +142,7 @@ class State(object):
         print(f"Finished simulation {iteration} for state {self}")
         print()
 
-    def _setup_dir(self, name, kT, dir_name=None):
+    def _setup_dir(self, name, kT, dir_name=None) -> str:
         """Create a state directory each time a new State is created."""
         if dir_name is None:
             if not os.path.isdir("states"):

--- a/msibi/state.py
+++ b/msibi/state.py
@@ -6,7 +6,6 @@ import warnings
 import gsd
 import gsd.hoomd
 import hoomd
-from msibi import MSIBI, utils
 
 
 class State(object):

--- a/msibi/utils/general.py
+++ b/msibi/utils/general.py
@@ -5,7 +5,6 @@ import shutil
 import numpy as np
 from pkg_resources import resource_filename
 import gc
-import msibi
 
 
 def find_nearest(array, target):


### PR DESCRIPTION
This is another PR following up the refactoring and move to hoomd4. It does a few things:

1. Adds more doc strings
2. Add type hints
3. Clean up imports
4. Moves the creation of the hoomd force objects outside of `State` and into `MSIBI`.
5. Method to smooth the potential being optimized
6. Method to save the potential being optimized to a table
7. Method to save all forces in the query simulations to a pickle file